### PR TITLE
Design: 결과페이지 줄바꿈 수정

### DIFF
--- a/src/pages/testPage/TestResultPage.styled.js
+++ b/src/pages/testPage/TestResultPage.styled.js
@@ -72,7 +72,7 @@ export const InfoBox = styled.div`
 
 export const InfoTextBox = styled.div`
   display: flex;
-  gap: 10px;
+  gap: 7px;
 `;
 //피모양 아이콘 크기조절할 디브
 export const InfoIcon = styled.div`


### PR DESCRIPTION
테스트 결과에서 줄바꿈할때 끝선안맞는문제 해결 

gap을10px로 해두니 길이가애매하게 남아서 이용하고 에서줄바꿈이 안되고 이용하/고 이렇게 된거같음 7px로 수정하니 아이폰기준 대부분의 기기에서 잘돼서 수정함 